### PR TITLE
Check command line arguments, e.g. whether file or directory exist, displaying a usage text if there's a problem.

### DIFF
--- a/php-class-splitter.php
+++ b/php-class-splitter.php
@@ -2,6 +2,7 @@
 <?php
 /*
  * Loop usage: find . -maxdepth 1 -name '*.php' -exec php php-class-splitter.php '{}' ';'
+ * Or:         find .  -name \*.php -exec ~/bin/php-class-splitter.php \{\} -p \;
  */
 function help($args)
 {
@@ -45,6 +46,11 @@ if ($argv[1] != '-p' && $argv[2] == '-p') {
 if ($argv[1] == '-p' && $argv[2] != '-p') {
     $file = $argv[2];
     $dest = dirname($file);
+}
+
+if (substr($file, 0, 1) == '-') {
+    help($argv);
+    die;
 }
 
 if (!file_exists($file)) {

--- a/php-class-splitter.php
+++ b/php-class-splitter.php
@@ -1,9 +1,39 @@
+#!/usr/bin/env php
 <?php
 /*
  * Loop usage: find . -maxdepth 1 -name '*.php' -exec php php-class-splitter.php '{}' ';'
-*/
+ */
+if ($argc != 3) {
+    help($argv);
+    exit;
+}
 $file = $argv[1];
-$dest = dirname($file);
+$dest = rtrim($argv[2], '/');
+function help($args)
+{
+    echo <<< EOM
+
+php $args[0] FILE DEST
+
+Splits a file containing multiple PHP classes up into multiple files with
+one class per file. Overwrites any existing files in the destination path
+with the same name, useful for handling redundant class definitions
+across multiple files. Requires the tokenizer extension.
+
+* FILE - path to a single PHP file containing multiple class definitions
+* DEST - path to a directory to contain the new class files
+
+EOM;
+}
+if (!file_exists($file)) {
+    die("Input file $file does not exist." . PHP_EOL);
+}
+if (!file_exists($dest)) {
+    die("$dest does not exist." . PHP_EOL);
+}
+if (!is_dir($dest)) {
+    die("$dest is not a directory." . PHP_EOL);
+}
 echo $file." => ".$dest . PHP_EOL;
 $tokens = token_get_all(file_get_contents($file));
 $mainheader=null;
@@ -17,8 +47,8 @@ while ($token = next($tokens)) {
         $braces = 1;
         do {
             $code .= is_string($token) ? $token : $token[1];
-            if (is_array($token) 
-                && $token[0] == T_STRING 
+            if (is_array($token)
+                && $token[0] == T_STRING
                 && empty($name)) {
                 $name = ucfirst($token[1]);
             }


### PR DESCRIPTION
Also, added a '-p' switch for specifying that generated files are to be created in the same directory as the originating file; this then keeps the described arguments in the usage text as standard with no surprises in store for the user.
